### PR TITLE
Read system parameters order was incorrect.

### DIFF
--- a/patchluastr.py
+++ b/patchluastr.py
@@ -77,9 +77,9 @@ if __name__ == "__main__":
     lua_sys_par = args.input.read(6)
     lua_endian = lua_sys_par[0]
     lua_int_size = lua_sys_par[1]
-    lua_sizet_size = lua_sys_par[2]
-    lua_instr_size = lua_sys_par[3]
-    lua_num_size = lua_sys_par[3]
+    lua_instr_size = lua_sys_par[2]
+    lua_sizet_size = lua_sys_par[3]
+    lua_num_size = lua_sys_par[4]
     print("Lua settings: endian %d, int %d, size_t %d, instruction %d, number %d" %
         (lua_endian, lua_int_size, lua_sizet_size, lua_instr_size, lua_num_size))
     if lua_endian != 1:


### PR DESCRIPTION
The comment (correctly) states that the system parameter order is (endianess, int size, instruction size, size_t size, lua num size, float)
but the code read (endian, int size, size_t size, instruction size, instruction size).

(Change is untested)