### PR TITLE
Fix typo for Issue #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ On Windows, use [Resource Hacker](http://www.angusj.com/resourcehacker/) to extr
 On Mac, the Lua files are directly accessible inside `Location.agmodule`:
 - Right-click `Location.agmodel` and select *Show Package Content*
 - Then navigate to `/Contents/Resources/`
-- Copy the files `LocationMapView.lua`, `AgReverseGeocodeService.lua` and `LocationDebugPanel` to the desired location for patching
+- Copy the files `LocationMapView.lua`, `AgReverseGeocodeService.lua` and `LocationDebugPanel.lua` to the desired location for patching
 
 ### 5. Patch Lua files
 


### PR DESCRIPTION
Line 79 in the README.md refers to "LocationDebugPanel.lua" but omits the ".lua" extension.  The actual file on the Mac does have the extension.